### PR TITLE
feat: add optional aws_region var

### DIFF
--- a/remote-ingestion-executor/main.tf
+++ b/remote-ingestion-executor/main.tf
@@ -76,7 +76,7 @@ module "ecs_service" {
         },
         {
           name  = "AWS_REGION"
-          value = data.aws_region.current.name
+          value = var.datahub.aws_region
         },
       ])
     }

--- a/remote-ingestion-executor/variables.tf
+++ b/remote-ingestion-executor/variables.tf
@@ -10,6 +10,8 @@ variable "datahub" {
     executor_id = optional(string, "remote")
     # SQS Queue ARN
     queue_url = string
+    # SQS Queue aws region
+    aws_region = optional(string, data.aws_region.current.name)
   })
 }
 


### PR DESCRIPTION
I'm currently trying to deploy a remote executor on my AWS account. The SQS queue has been deployed in eu-central-1 while my AWS resources are in eu-west-1. I'm adding the possibility of setting up its aws region if necessary.