### PR TITLE
added remote executor terraform helm deploy script for GKE

### DIFF
--- a/remote-ingestion-executor-gke/README.md
+++ b/remote-ingestion-executor-gke/README.md
@@ -1,0 +1,235 @@
+# DataHub Remote Executor on GKE
+
+This repository contains Terraform configuration and sample resources for deploying DataHub Remote Executor to Google Kubernetes Engine (GKE) with custom transformers support.
+
+## 🏗️ Repository Structure
+
+```
+.
+├── README.md                           # This file
+├── docs/                              # Documentation
+├── sample/                           # Sample configurations and transformers
+│   └── sample-setup.md               # Sample data source and transformer setup guide
+│   ├── transformers/                 # Custom transformer examples
+│   │   ├── custom_transform_example.py
+│   │   ├── setup.py
+│   │   └── owners.json
+│   └── source/                       # Sample data source configurations
+│       ├── postgres-config.yaml
+│       ├── postgres-deployment.yaml
+│       └── postgres-recipe.yaml
+├── datahub-executor-helm/            # Helm chart for DataHub executor
+│   └── charts/
+│       └── datahub-executor-worker/
+├── main.tf                          # Main Terraform configuration
+├── variables.tf                     # Variable definitions
+├── outputs.tf                       # Output definitions
+├── versions.tf                      # Provider version constraints
+├── helm-values.yaml.tpl             # Helm values template
+├── terraform.tfvars.example         # Example variables file
+├── .gitignore                       # Git ignore rules
+└── deploy.sh                        # Quick deployment script
+```
+
+## 🚀 Quick Start
+
+### Prerequisites
+
+1. **GCP Project and GKE Cluster**: Ensure you have a GCP project with an existing GKE cluster
+2. **Terraform**: Install Terraform >= 1.0
+3. **gcloud CLI**: Install and authenticate with `gcloud auth application-default login`
+4. **kubectl**: Install kubectl for cluster management
+5. **DataHub Instance**: Access to a DataHub instance with API token
+
+### 1. Configure Variables
+
+Copy the example variables file and customize it:
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars` with your specific values:
+
+```hcl
+# Required variables
+project_id     = "your-gcp-project-id"
+cluster_name   = "your-gke-cluster-name"
+region         = "us-central1"
+
+# DataHub Configuration
+datahub_gms_url      = "https://your-datahub-instance.com/gms"
+datahub_access_token = "your-datahub-access-token"
+
+# Container Registry Configuration
+container_registry_url      = "gcr.io/your-project-id"
+container_registry_username = "_json_key"
+container_registry_password = "your-service-account-key-json"
+
+# Custom Transformers (automatically enabled when path is set)
+custom_transformers_path = "sample/transformers"  # Set to "" to disable
+```
+
+### 2. Deploy
+
+Initialize and apply Terraform:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+### 3. Verify Deployment
+
+Check that the executor is running:
+
+```bash
+# Get kubectl configuration
+gcloud container clusters get-credentials your-cluster-name --region your-region --project your-project-id
+
+# Check pods
+kubectl get pods -n datahub-remote-executor
+
+# View logs
+kubectl logs -n datahub-remote-executor -l app.kubernetes.io/name=datahub-executor-worker --tail=50
+```
+
+## 🔧 Configuration Options
+
+### Required Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `project_id` | GCP project ID | `"my-project-123"` |
+| `cluster_name` | Existing GKE cluster name | `"my-gke-cluster"` |
+| `datahub_gms_url` | DataHub GMS endpoint | `"https://datahub.company.com/gms"` |
+| `datahub_access_token` | DataHub access token | `"your-token"` |
+| `container_registry_password` | Registry password/key | `"service-account-json"` |
+
+### Optional Variables with Defaults
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `region` | `"us-central1"` | GCP region |
+| `kubernetes_namespace` | `"datahub-remote-executor"` | K8s namespace |
+| `environment` | `"dev"` | Environment (dev/test/prod) |
+| `datahub_remote_executor_pool_id` | `"gke-executor-pool"` | Executor pool ID |
+| `replica_count` | `1` | Number of replicas |
+| `custom_transformers_path` | `"sample/transformers"` | Path to custom transformers |
+
+## 🔄 Custom Transformers
+
+The repository includes built-in support for custom DataHub transformers:
+
+### Automatic Enablement
+Custom transformers are automatically enabled when `custom_transformers_path` is set to a non-empty value.
+
+### Transformer Structure
+Place your transformer files in the specified directory:
+```
+sample/transformers/
+├── custom_transform_example.py  # Your transformer code
+├── setup.py                    # Python package setup
+└── owners.json                 # Configuration files
+```
+
+### Disabling Transformers
+Set `custom_transformers_path = ""` in your `terraform.tfvars` to disable custom transformers.
+
+## 🐘 Sample Data Source
+
+The repository includes a sample PostgreSQL setup in `sample/source/` for testing purposes. See [Sample Setup Guide](docs/sample-setup.md) for detailed instructions on:
+
+- Setting up a PostgreSQL data source
+- Configuring ingestion recipes
+- Using custom transformers
+- Testing the complete pipeline
+
+## 🏗️ Architecture
+
+### Components
+
+1. **GKE Cluster**: Kubernetes cluster hosting the executor
+2. **DataHub Executor**: Remote executor pods processing ingestion tasks
+3. **ConfigMaps**: Store custom transformer code and configuration
+4. **Secrets**: Secure storage for DataHub tokens and registry credentials
+5. **Custom Transformers**: Optional Python modules for data transformation
+
+### Flow
+
+1. DataHub schedules ingestion tasks to the remote executor pool
+2. Executor pods pull tasks from the queue
+3. Custom transformers are automatically installed via init containers
+4. Ingestion runs with custom transformations applied
+5. Results are sent back to DataHub
+
+## 🔐 Security Considerations
+
+1. **Secrets Management**: Sensitive values stored in Kubernetes secrets
+2. **Network Security**: Configure appropriate network policies
+3. **RBAC**: Service account with minimal required permissions
+4. **Workload Identity**: Optional for enhanced security (set `enable_workload_identity = true`)
+5. **Image Security**: Regular image updates and vulnerability scanning
+
+## 🛠️ Troubleshooting
+
+### Common Issues
+
+1. **ImagePullBackOff**: Check container registry credentials
+2. **CrashLoopBackOff**: Verify DataHub GMS URL and access token
+3. **Pending Pods**: Check node resources and tolerations
+4. **Transformer Installation Failures**: Check transformer setup.py syntax
+
+### Debugging Commands
+
+The Terraform outputs provide useful debugging commands:
+
+```bash
+# Check pods
+kubectl get pods -n datahub-remote-executor
+
+# View executor logs
+kubectl logs -n datahub-remote-executor -l app.kubernetes.io/name=datahub-executor-worker --tail=100
+
+# Check secrets
+kubectl get secrets -n datahub-remote-executor
+
+# Describe deployment
+kubectl describe deployment datahub-executor-datahub-executor-worker -n datahub-remote-executor
+```
+
+## 🧹 Cleanup
+
+To remove all resources:
+
+```bash
+terraform destroy
+```
+
+## 📚 Additional Resources
+
+- [DataHub Documentation](https://datahubproject.io/docs/)
+- [DataHub Remote Executor Guide](https://datahubproject.io/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor)
+- [Custom Transformers Documentation](https://datahubproject.io/docs/metadata-ingestion/docs/transformer/intro)
+- [Sample Setup Guide](docs/sample-setup.md)
+
+## 🤝 Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Test the deployment
+5. Submit a pull request
+
+## 📄 License
+
+This project is licensed under the MIT License - see the LICENSE file for details.
+
+## 🆘 Support
+
+For issues related to:
+- **Terraform configuration**: Check this documentation and Terraform logs
+- **Helm chart**: Refer to the Helm chart documentation in `datahub-executor-helm/`
+- **DataHub Executor**: Check DataHub documentation and executor logs
+- **GKE/GCP**: Consult Google Cloud documentation

--- a/remote-ingestion-executor-gke/datahub-executor-helm/README.md
+++ b/remote-ingestion-executor-gke/datahub-executor-helm/README.md
@@ -1,0 +1,13 @@
+# DataHub Executor Helm
+
+## Overview
+
+This repository contains Helm charts for deploying the DataHub Remote Executor, an agent that is able to run ingestion and monitoring tasks inside a remote cloud environment. 
+
+## Support
+
+Looking for support? Please reach out to [help@acryl.io](mailto://help@acryl.io). 
+
+## FAQ
+
+Coming soon! 

--- a/remote-ingestion-executor-gke/datahub-executor-helm/charts/datahub-executor-worker/Chart.yaml
+++ b/remote-ingestion-executor-gke/datahub-executor-helm/charts/datahub-executor-worker/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: datahub-executor-worker
+description: A Helm chart for datahub-executor-worker
+type: application
+version: 0.0.26
+appVersion: 0.3.13
+maintainers:
+  - name: DataHub
+    email: datahub@acryl.io

--- a/remote-ingestion-executor-gke/datahub-executor-helm/charts/datahub-executor-worker/README.md
+++ b/remote-ingestion-executor-gke/datahub-executor-helm/charts/datahub-executor-worker/README.md
@@ -1,0 +1,12 @@
+## Example usage
+
+```
+# Create secret object with GMS access token. Note that secret name and key must match those in values file
+$ kubectl create secret generic datahub-access-token-secret --from-literal=datahub-access-token-secret-key=<DATAHUB-ACCESS-TOKEN>
+
+# Deploy executor with worker ID "remote" and GMS URL "https://company.acryl.io/gms"
+$ helm install \
+  --set global.datahub.executor.pool_id="remote" \
+  --set global.datahub.gms.url="https://company.acryl.io/gms" \
+    default ./charts/datahub-executor-worker
+```

--- a/remote-ingestion-executor-gke/datahub-executor-helm/charts/datahub-executor-worker/templates/_helpers.tpl
+++ b/remote-ingestion-executor-gke/datahub-executor-helm/charts/datahub-executor-worker/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "datahub-executor-worker.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "datahub-executor-worker.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "datahub-executor-worker.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "datahub-executor-worker.labels" -}}
+helm.sh/chart: {{ include "datahub-executor-worker.chart" . }}
+{{ include "datahub-executor-worker.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "datahub-executor-worker.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "datahub-executor-worker.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "datahub-executor-worker.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "datahub-executor-worker.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/remote-ingestion-executor-gke/datahub-executor-helm/charts/datahub-executor-worker/templates/pod-disruption-budget.yaml
+++ b/remote-ingestion-executor-gke/datahub-executor-helm/charts/datahub-executor-worker/templates/pod-disruption-budget.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.pdb.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "datahub-executor-worker.fullname" . }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "datahub-executor-worker.selectorLabels" . | nindent 6 }}
+{{- end -}}

--- a/remote-ingestion-executor-gke/datahub-executor-helm/charts/datahub-executor-worker/templates/serviceaccount.yaml
+++ b/remote-ingestion-executor-gke/datahub-executor-helm/charts/datahub-executor-worker/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "datahub-executor-worker.serviceAccountName" . }}
+  labels:
+    {{- include "datahub-executor-worker.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/remote-ingestion-executor-gke/datahub-executor-helm/charts/datahub-executor-worker/templates/workload.yaml
+++ b/remote-ingestion-executor-gke/datahub-executor-helm/charts/datahub-executor-worker/templates/workload.yaml
@@ -1,0 +1,180 @@
+apiVersion: apps/v1
+kind: {{ .Values.workloadKind }}
+metadata:
+  name: {{ include "datahub-executor-worker.fullname" . }}
+  labels:
+    {{- include "datahub-executor-worker.labels" . | nindent 4 }}
+    {{- range $key, $val := .Values.extraLabels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+spec:
+  replicas: {{if .Values.global.readonly}} 0 {{else}} {{ .Values.replicaCount }} {{end}}
+  selector:
+    matchLabels:
+      {{- include "datahub-executor-worker.selectorLabels" . | nindent 6 }}
+  {{- if .Values.persistentVolume.enabled }}
+  {{- if ne .Values.workloadKind "StatefulSet" }}
+  {{- fail "workloadKind must be set to StatefulSet when persistent volume is enabled" }}
+  {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        {{- with .Values.persistentVolume.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.persistentVolume.labels }}
+        labels:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        name: executor-storage-volume
+      spec:
+        accessModes:
+          {{ toYaml .Values.persistentVolume.accessModes }}
+      {{- if .Values.persistentVolume.storageClass }}
+      {{- if (eq "-" .Values.persistentVolume.storageClass) }}
+        storageClassName: ""
+      {{- else }}
+        storageClassName: "{{ .Values.persistentVolume.storageClass }}"
+      {{- end }}
+      {{- end }}
+        resources:
+          requests:
+            storage: "{{ .Values.persistentVolume.size }}"
+  {{- end }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "datahub-executor-worker.selectorLabels" . | nindent 8 }}
+        {{- range $key, $value := .Values.extraPodLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "datahub-executor-worker.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+      {{- with .Values.extraCaCerts }}
+          - name: ca-certs
+            emptyDir: {}
+      {{- range $key, $value := . }}
+          - name: {{ $key }}
+            secret:
+              secretName: {{ $value }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+        {{ toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
+      initContainers:
+      {{- if .Values.extraCaCerts }}
+        - name: install-ca-certs
+          image: "{{ .Values.image.repository }}:{{ required "image tag is required" .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/bash", "-c"]
+          args:
+            - update-ca-certificates && cp -Lr /etc/ssl/certs/. /mnt/ca-certs/
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          volumeMounts:
+            - name: ca-certs
+              mountPath: /mnt/ca-certs
+            {{- with .Values.extraCaCerts -}}
+            {{ range $key, $value := . }}
+            - mountPath: "/usr/local/share/ca-certificates/{{ $key }}"
+              name: {{ $key | quote }}
+              readOnly: true
+            {{- end }}
+            {{- end }}
+      {{- end }}
+      {{- if .Values.extraInitContainers }}
+      {{- .Values.extraInitContainers | toYaml | nindent 6 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ required "image tag is required" .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["dockerize", "/start_datahub_executor.sh"]
+          livenessProbe:
+            exec:
+              command:
+              - /health_status
+              - /tmp/worker_liveness_heartbeat
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          readinessProbe:
+            exec:
+              command:
+              - /health_status
+              - /tmp/worker_readiness_heartbeat
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          env:
+            - name: DATAHUB_GMS_URL
+              value: {{ ((.Values.global.datahub).gms).url }}
+            - name: DATAHUB_GMS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ ((.Values.global.datahub).gms).secretRef }}
+                  key: {{ ((.Values.global.datahub).gms).secretKey }}
+            - name: DATAHUB_EXECUTOR_MODE
+              value: "worker"
+            - name: DATAHUB_EXECUTOR_POOL_ID
+              value: {{ .Values.global.datahub.executor.pool_id | quote }}
+            - name: DATAHUB_EXECUTOR_WORKER_ID
+              value: {{ .Values.global.datahub.executor.pool_id | quote }}
+            - name: DATAHUB_EXECUTOR_INGESTION_MAX_WORKERS
+              value: {{ .Values.global.datahub.executor.ingestions.max_workers | quote }}
+            - name: DATAHUB_EXECUTOR_INGESTION_SIGNAL_POLL_INTERVAL
+              value: {{ .Values.global.datahub.executor.ingestions.signal_poll_interval | quote }}
+            - name: DATAHUB_EXECUTOR_MONITORS_MAX_WORKERS
+              value: {{ .Values.global.datahub.executor.monitors.max_workers | quote }}
+          {{- if .Values.extraEnvs -}}
+            {{ toYaml .Values.extraEnvs | nindent 12 }}
+          {{- end }}
+          {{- if .Values.extraEnvsFrom }}
+          envFrom:
+            {{- toYaml .Values.extraEnvsFrom | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.extraCaCerts }}
+            - name: ca-certs
+              mountPath: /etc/ssl/certs
+            {{- end }}
+          {{- if .Values.persistentVolume.enabled }}
+            - name: executor-storage-volume
+              mountPath: {{ .Values.persistentVolume.mountPath }}
+          {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+            {{ toYaml .Values.extraVolumeMounts | nindent 10 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/remote-ingestion-executor-gke/datahub-executor-helm/charts/datahub-executor-worker/values.yaml
+++ b/remote-ingestion-executor-gke/datahub-executor-helm/charts/datahub-executor-worker/values.yaml
@@ -1,0 +1,108 @@
+global:
+  datahub:
+    gms:
+      secretRef: datahub-access-token-secret
+      secretKey: datahub-access-token-secret-key
+      url: https://datahub.acryl.io/gms
+    executor:
+      pool_id: "remote"
+      ingestions:
+        max_workers: 4
+        signal_poll_interval: 2
+      monitors:
+        max_workers: 10
+
+workloadKind: Deployment
+
+replicaCount: 1
+
+revisionHistoryLimit: 1
+
+image:
+  # GCP: us-docker.pkg.dev/acryl-prod/datahub/datahub-executor
+  repository: 795586375822.dkr.ecr.us-west-2.amazonaws.com/datahub-executor
+  pullPolicy: Always
+  tag: v0.3.13-acryl
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+terminationGracePeriodSeconds: 150
+
+pdb:
+  enabled: false
+  minAvailable: 1
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+podAnnotations: {}
+  # co.elastic.logs/enabled: "true"
+
+podSecurityContext:
+  fsGroup: 1000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+extraEnvs: []
+
+extraVolumes: []
+
+extraVolumeMounts: []
+
+extraInitContainers: []
+
+extraCaCerts: {}
+
+extraLabels: {}
+
+extraPodLabels: {}
+
+resources:
+  requests:
+    memory: "8Gi"
+    cpu: "4"
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+livenessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 60
+  failureThreshold: 3
+  timeoutSeconds: 5
+
+readinessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 60
+  failureThreshold: 3
+  timeoutSeconds: 5
+
+persistentVolume:
+  # Requires workloadKind: StatefulSet
+  enabled: false
+  accessModes:
+    - ReadWriteOnce
+  annotations: {}
+  labels: {}
+  existingClaim: ""
+  mountPath: /tmp/datahub
+  size: 100Gi
+  # storageClass: "-"
+  subPath: ""

--- a/remote-ingestion-executor-gke/helm-values.yaml.tpl
+++ b/remote-ingestion-executor-gke/helm-values.yaml.tpl
@@ -1,0 +1,111 @@
+global:
+  datahub:
+    gms:
+      url: "${datahub_gms_url}"
+      secretRef: "${datahub_secret_name}"
+      secretKey: "token"
+    executor:
+      pool_id: "${executor_pool_id}"
+      ingestions:
+        max_workers: ${ingestion_max_workers}
+        signal_poll_interval: ${ingestion_signal_poll_interval}
+      monitors:
+        max_workers: ${monitors_max_workers}
+
+workloadKind: "Deployment"
+replicaCount: ${replica_count}
+
+image:
+  repository: "${image_repository}"
+  pullPolicy: "Always"
+  tag: "${image_tag}"
+
+imagePullSecrets:
+  - name: "${registry_secret_name}"
+
+resources:
+  requests:
+    memory: "${resources_requests_memory}"
+    cpu: "${resources_requests_cpu}"
+  limits:
+    memory: "${resources_limits_memory}"
+    cpu: "${resources_limits_cpu}"
+
+serviceAccount:
+  create: true
+  name: "datahub-executor-sa"
+%{ if enable_workload_identity ~}
+  annotations:
+    iam.gke.io/gcp-service-account: "${gcp_service_account_email}"
+%{ else ~}
+  annotations: {}
+%{ endif ~}
+
+podAnnotations:
+%{ for key, value in pod_annotations ~}
+  ${key}: "${value}"
+%{ endfor ~}
+  environment: "${environment}"
+
+podSecurityContext:
+  fsGroup: 1000
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+
+livenessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  failureThreshold: 3
+  timeoutSeconds: 5
+
+readinessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  failureThreshold: 3
+  timeoutSeconds: 5
+
+%{ if length(node_selector) > 0 ~}
+nodeSelector:
+%{ for key, value in node_selector ~}
+  ${key}: "${value}"
+%{ endfor ~}
+%{ else ~}
+nodeSelector: {}
+%{ endif ~}
+
+%{ if length(tolerations) > 0 ~}
+tolerations:
+%{ for toleration in tolerations ~}
+  - %{ if toleration.key != null }key: "${toleration.key}"%{ endif }
+    %{ if toleration.operator != null }operator: "${toleration.operator}"%{ endif }
+    %{ if toleration.value != null }value: "${toleration.value}"%{ endif }
+    %{ if toleration.effect != null }effect: "${toleration.effect}"%{ endif }
+%{ endfor ~}
+%{ else ~}
+tolerations: []
+%{ endif ~}
+
+extraEnvs:
+%{ if enable_debug ~}
+  - name: "DATAHUB_DEBUG"
+    value: "true"
+%{ endif ~}
+%{ if enable_custom_transformers ~}
+  - name: "PYTHONPATH"
+    value: "/opt/datahub/transformers:$PYTHONPATH"
+%{ endif ~}
+
+%{ if enable_custom_transformers ~}
+# Custom transformer volume (single configmap with all files)
+extraVolumes:
+  - name: custom-transformers
+    configMap:
+      name: "${custom_transformers_configmap}"
+      defaultMode: 0755
+
+extraVolumeMounts:
+  - mountPath: /opt/datahub/transformers
+    name: custom-transformers
+%{ endif ~}

--- a/remote-ingestion-executor-gke/main.tf
+++ b/remote-ingestion-executor-gke/main.tf
@@ -1,0 +1,187 @@
+# Main Terraform configuration for DataHub Remote Executor on GKE
+
+# Configure the Google Cloud Provider
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Data source to get GKE cluster information
+data "google_container_cluster" "primary" {
+  name     = var.cluster_name
+  location = var.region
+  project  = var.project_id
+}
+
+# Configure the Kubernetes Provider
+provider "kubernetes" {
+  host                   = "https://${data.google_container_cluster.primary.endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(data.google_container_cluster.primary.master_auth.0.cluster_ca_certificate)
+}
+
+# Configure the Helm Provider
+provider "helm" {
+  kubernetes {
+    host                   = "https://${data.google_container_cluster.primary.endpoint}"
+    token                  = data.google_client_config.default.access_token
+    cluster_ca_certificate = base64decode(data.google_container_cluster.primary.master_auth.0.cluster_ca_certificate)
+  }
+}
+
+# Get Google client configuration for authentication
+data "google_client_config" "default" {}
+
+# Create namespace if specified
+resource "kubernetes_namespace" "datahub_executor" {
+  count = var.create_namespace ? 1 : 0
+  
+  metadata {
+    name = var.kubernetes_namespace
+    
+    labels = {
+      environment = var.environment
+      app         = "datahub-executor"
+    }
+  }
+}
+
+# Create GCP Service Account for Workload Identity (if enabled)
+resource "google_service_account" "datahub_executor" {
+  count = var.enable_workload_identity ? 1 : 0
+  
+  account_id   = var.gcp_service_account_name
+  display_name = "DataHub Executor Service Account"
+  description  = "Service account for DataHub Remote Executor with Workload Identity"
+  project      = var.project_id
+}
+
+# Bind GCP Service Account to Kubernetes Service Account (if Workload Identity is enabled)
+resource "google_service_account_iam_binding" "workload_identity" {
+  count = var.enable_workload_identity ? 1 : 0
+  
+  service_account_id = google_service_account.datahub_executor[0].name
+  role               = "roles/iam.workloadIdentityUser"
+  
+  members = [
+    "serviceAccount:${var.project_id}.svc.id.goog[${var.kubernetes_namespace}/datahub-executor-sa]"
+  ]
+}
+
+# Create Kubernetes secret for DataHub access token
+resource "kubernetes_secret" "datahub_access_token" {
+  depends_on = [kubernetes_namespace.datahub_executor]
+  
+  metadata {
+    name      = "datahub-access-token"
+    namespace = var.kubernetes_namespace
+    
+    labels = {
+      environment = var.environment
+      app         = "datahub-executor"
+    }
+  }
+  
+  data = {
+    token = var.datahub_access_token
+  }
+  
+  type = "Opaque"
+}
+
+# Create Kubernetes secret for container registry credentials
+resource "kubernetes_secret" "container_registry" {
+  depends_on = [kubernetes_namespace.datahub_executor]
+  
+  metadata {
+    name      = "datahub-docker-registry"
+    namespace = var.kubernetes_namespace
+    
+    labels = {
+      environment = var.environment
+      app         = "datahub-executor"
+    }
+  }
+  
+  data = {
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        (var.container_registry_url) = {
+          username = var.container_registry_username
+          password = var.container_registry_password
+          auth     = base64encode("${var.container_registry_username}:${var.container_registry_password}")
+        }
+      }
+    })
+  }
+  
+  type = "kubernetes.io/dockerconfigjson"
+}
+
+# Create ConfigMap for custom transformers (single configmap with all files)
+locals {
+  enable_custom_transformers = var.custom_transformers_path != "" && var.custom_transformers_path != null
+}
+
+resource "kubernetes_config_map" "custom_transformers" {
+  count = local.enable_custom_transformers ? 1 : 0
+  depends_on = [kubernetes_namespace.datahub_executor]
+  
+  metadata {
+    name      = "custom-transformers"
+    namespace = var.kubernetes_namespace
+    
+    labels = {
+      environment = var.environment
+      app         = "datahub-executor"
+    }
+  }
+  
+  data = {
+    for filename in fileset("${path.module}/${var.custom_transformers_path}", "*") :
+    filename => file("${path.module}/${var.custom_transformers_path}/${filename}")
+    if !startswith(filename, ".") # Skip hidden files like .DS_Store
+  }
+}
+
+# Deploy DataHub Executor using Helm
+resource "helm_release" "datahub_executor" {
+  name       = var.helm_release_name
+  chart      = var.helm_chart_path
+  namespace  = var.kubernetes_namespace
+  
+  # Force recreation if namespace is created
+  depends_on = [
+    kubernetes_secret.datahub_access_token,
+    kubernetes_secret.container_registry,
+    kubernetes_config_map.custom_transformers
+  ]
+  
+  values = [
+    templatefile("${path.module}/helm-values.yaml.tpl", {
+      datahub_gms_url                   = var.datahub_gms_url
+      datahub_secret_name              = kubernetes_secret.datahub_access_token.metadata[0].name
+      executor_pool_id                 = var.datahub_remote_executor_pool_id
+      ingestion_max_workers            = var.ingestion_max_workers
+      ingestion_signal_poll_interval   = var.ingestion_signal_poll_interval
+      monitors_max_workers             = var.monitors_max_workers
+      replica_count                    = var.replica_count
+      image_repository                 = var.image_repository
+      image_tag                        = var.image_tag
+      registry_secret_name             = kubernetes_secret.container_registry.metadata[0].name
+      resources_requests_memory        = var.resources_requests_memory
+      resources_requests_cpu           = var.resources_requests_cpu
+      resources_limits_memory          = var.resources_limits_memory
+      resources_limits_cpu             = var.resources_limits_cpu
+      enable_workload_identity         = var.enable_workload_identity
+      gcp_service_account_email        = var.enable_workload_identity ? google_service_account.datahub_executor[0].email : ""
+      pod_annotations                  = var.pod_annotations
+      environment                      = var.environment
+      node_selector                    = var.node_selector
+      tolerations                      = var.tolerations
+      enable_debug                     = var.enable_debug
+      enable_custom_transformers       = local.enable_custom_transformers
+      custom_transformers_configmap    = local.enable_custom_transformers ? kubernetes_config_map.custom_transformers[0].metadata[0].name : ""
+    })
+  ]
+}

--- a/remote-ingestion-executor-gke/outputs.tf
+++ b/remote-ingestion-executor-gke/outputs.tf
@@ -1,0 +1,95 @@
+# Output values for DataHub Remote Executor deployment
+
+output "cluster_name" {
+  description = "Name of the GKE cluster"
+  value       = var.cluster_name
+}
+
+output "cluster_endpoint" {
+  description = "Endpoint of the GKE cluster"
+  value       = data.google_container_cluster.primary.endpoint
+  sensitive   = true
+}
+
+output "namespace" {
+  description = "Kubernetes namespace where DataHub executor is deployed"
+  value       = var.kubernetes_namespace
+}
+
+output "helm_release_name" {
+  description = "Name of the Helm release"
+  value       = helm_release.datahub_executor.name
+}
+
+output "helm_release_status" {
+  description = "Status of the Helm release"
+  value       = helm_release.datahub_executor.status
+}
+
+output "datahub_gms_url" {
+  description = "DataHub GMS endpoint URL"
+  value       = var.datahub_gms_url
+}
+
+output "datahub_remote_executor_pool_id" {
+  description = "DataHub executor pool ID"
+  value       = var.datahub_remote_executor_pool_id
+}
+
+output "image_repository" {
+  description = "DataHub executor image repository"
+  value       = var.image_repository
+}
+
+output "image_tag" {
+  description = "DataHub executor image tag"
+  value       = var.image_tag
+}
+
+output "replica_count" {
+  description = "Number of executor replicas"
+  value       = var.replica_count
+}
+
+output "environment" {
+  description = "Deployment environment"
+  value       = var.environment
+}
+
+output "gcp_service_account_email" {
+  description = "Email of the GCP service account (if Workload Identity is enabled)"
+  value       = var.enable_workload_identity ? google_service_account.datahub_executor[0].email : null
+}
+
+output "kubernetes_service_account_name" {
+  description = "Name of the Kubernetes service account"
+  value       = "datahub-executor-sa"
+}
+
+output "datahub_access_token_secret_name" {
+  description = "Name of the Kubernetes secret containing DataHub access token"
+  value       = kubernetes_secret.datahub_access_token.metadata[0].name
+}
+
+output "container_registry_secret_name" {
+  description = "Name of the Kubernetes secret for container registry credentials"
+  value       = kubernetes_secret.container_registry.metadata[0].name
+}
+
+# Connection information for kubectl
+output "kubectl_config_command" {
+  description = "Command to configure kubectl for the cluster"
+  value       = "gcloud container clusters get-credentials ${var.cluster_name} --region ${var.region} --project ${var.project_id}"
+}
+
+# Useful debugging commands
+output "debugging_commands" {
+  description = "Useful commands for debugging the deployment"
+  value = {
+    check_pods           = "kubectl get pods -n ${var.kubernetes_namespace}"
+    check_logs          = "kubectl logs -n ${var.kubernetes_namespace} -l app.kubernetes.io/name=datahub-executor-worker --tail=100"
+    check_secrets       = "kubectl get secrets -n ${var.kubernetes_namespace}"
+    check_helm_release  = "helm list -n ${var.kubernetes_namespace}"
+    describe_deployment = "kubectl describe deployment ${var.helm_release_name}-datahub-executor-worker -n ${var.kubernetes_namespace}"
+  }
+}

--- a/remote-ingestion-executor-gke/sample/sample-setup.md
+++ b/remote-ingestion-executor-gke/sample/sample-setup.md
@@ -1,0 +1,355 @@
+# Sample Data Source and Transformer Setup Guide
+
+This guide walks you through setting up the sample PostgreSQL data source, custom transformers, and testing the complete DataHub ingestion pipeline with the remote executor.
+
+## 📋 Overview
+
+The sample setup includes:
+- **PostgreSQL Database**: Sample data source with test tables
+- **Custom Transformer**: Adds ownership metadata to ingested datasets
+- **Ingestion Recipe**: Configuration for DataHub ingestion
+- **Remote Executor**: Processes ingestion with custom transformations
+
+## 🐘 PostgreSQL Data Source Setup
+
+### 1. Deploy Sample PostgreSQL
+
+The repository includes Kubernetes manifests for a sample PostgreSQL instance:
+
+```bash
+# Deploy PostgreSQL to your GKE cluster
+kubectl apply -f sample/source/postgres-config.yaml
+kubectl apply -f sample/source/postgres-deployment.yaml
+
+# Wait for PostgreSQL to be ready
+kubectl wait --for=condition=ready pod -l app=postgres --timeout=300s
+```
+
+### 2. Verify PostgreSQL Deployment
+
+```bash
+# Check if PostgreSQL is running
+kubectl get pods -l app=postgres
+
+# Check service
+kubectl get svc postgres-service
+
+# Test connection (optional)
+kubectl exec -it deployment/postgres -- psql -U testuser -d testdb -c "SELECT version();"
+```
+
+### 3. Sample Database Schema
+
+The PostgreSQL instance comes pre-configured with sample data:
+
+```sql
+-- Sample tables that will be ingested
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    username VARCHAR(50),
+    email VARCHAR(100),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE orders (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id),
+    product_name VARCHAR(100),
+    amount DECIMAL(10,2),
+    order_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Sample data
+INSERT INTO users (username, email) VALUES 
+    ('alice', 'alice@example.com'),
+    ('bob', 'bob@example.com');
+
+INSERT INTO orders (user_id, product_name, amount) VALUES 
+    (1, 'Widget A', 29.99),
+    (2, 'Widget B', 39.99);
+```
+
+## 🔧 Custom Transformer Configuration
+
+### 1. Understanding the Sample Transformer
+
+The sample transformer (`sample/transformers/custom_transform_example.py`) demonstrates:
+
+```python
+class AddCustomOwnership(BaseTransformer, SingleAspectTransformer):
+    """Transformer that adds owners to datasets according to a callback function."""
+    
+    def transform_aspect(self, entity_urn: str, aspect_name: str, aspect: Optional[OwnershipClass]) -> Optional[OwnershipClass]:
+        # Adds predefined owners to all datasets
+        owners_to_add = self.owners  # Loaded from owners.json
+        # ... transformation logic
+```
+
+### 2. Customizing Ownership
+
+Edit `sample/transformers/owners.json` to customize ownership:
+
+```json
+[
+  "urn:li:corpuser:your-username",
+  "urn:li:corpuser:data-engineer",
+  "urn:li:corpGroup:data-team"
+]
+```
+
+### 3. Transformer Entry Points
+
+The `setup.py` file registers the transformer:
+
+```python
+entry_points={
+    "datahub.ingestion.transformer.plugins": [
+        "custom_transform_example_alias = custom_transform_example:AddCustomOwnership",
+    ],
+}
+```
+
+## 📝 Ingestion Recipe Configuration
+
+### 1. Sample Recipe Structure
+
+The sample recipe (`sample/source/postgres-recipe.yaml`) configures:
+
+```yaml
+source:
+  type: postgres
+  config:
+    host_port: postgres-service:5432
+    database: testdb
+    username: testuser
+    password: testpass
+    
+transformers:
+  - type: "custom_transform_example_alias"
+    config:
+      owners_json: "/opt/datahub/transformers/owners.json"
+
+sink:
+  type: "datahub-rest"
+  config:
+    server: "${DATAHUB_GMS_URL}"
+    token: "${DATAHUB_GMS_TOKEN}"
+```
+
+### 2. Recipe Customization
+
+To customize the ingestion:
+
+1. **Database Configuration**: Update connection details in the `source.config` section
+2. **Table Filtering**: Add `table_pattern` to include/exclude specific tables
+3. **Schema Mapping**: Configure schema and database naming
+4. **Transformer Parameters**: Modify transformer configuration
+
+Example with table filtering:
+
+```yaml
+source:
+  type: postgres
+  config:
+    host_port: postgres-service:5432
+    database: testdb
+    username: testuser
+    password: testpass
+    table_pattern:
+      allow:
+        - "public.users"
+        - "public.orders"
+      deny:
+        - "public.temp_.*"
+```
+
+## 🚀 Running the Complete Pipeline
+
+### 1. Deploy the Remote Executor
+
+Ensure your Terraform deployment is complete:
+
+```bash
+# Check executor status
+kubectl get pods -n datahub-remote-executor
+
+# Verify custom transformers are loaded
+kubectl logs -n datahub-remote-executor -l app.kubernetes.io/name=datahub-executor-worker --tail=50 | grep "transformer"
+```
+
+### 2. Create Ingestion Source in DataHub
+
+1. **Navigate to DataHub UI** → Ingestion → Sources
+2. **Create New Source**:
+   - Source Type: PostgreSQL
+   - Executor: Select your remote executor pool (`gke-executor-pool`)
+   - Recipe: Copy content from `sample/source/postgres-recipe.yaml`
+
+3. **Configure Connection**:
+   - Host: `postgres-service.default.svc.cluster.local:5432` (if PostgreSQL is in default namespace)
+   - Database: `testdb`
+   - Username: `testuser`
+   - Password: `testpass`
+
+### 3. Test the Ingestion
+
+1. **Run Ingestion**: Click "Execute" in DataHub UI
+2. **Monitor Progress**: Watch the ingestion logs in DataHub
+3. **Check Executor Logs**:
+   ```bash
+   kubectl logs -n datahub-remote-executor -l app.kubernetes.io/name=datahub-executor-worker -f
+   ```
+
+### 4. Verify Results
+
+After successful ingestion:
+
+1. **Check Datasets**: Navigate to DataHub UI → Browse → Datasets
+2. **Verify Ownership**: Look for datasets with the custom ownership applied
+3. **Inspect Metadata**: Check that schema and lineage information is captured
+
+## 🔍 Troubleshooting
+
+### Common Issues
+
+#### 1. Connection Issues
+```bash
+# Check if PostgreSQL is accessible from executor
+kubectl exec -it deployment/datahub-executor-datahub-executor-worker -n datahub-remote-executor -- nslookup postgres-service.default.svc.cluster.local
+```
+
+#### 2. Transformer Not Loading
+```bash
+# Check if transformer files are mounted
+kubectl exec -it deployment/datahub-executor-datahub-executor-worker -n datahub-remote-executor -- ls -la /opt/datahub/transformers/
+
+# Verify transformer installation
+kubectl logs -n datahub-remote-executor -l app.kubernetes.io/name=datahub-executor-worker | grep "install"
+```
+
+#### 3. Authentication Issues
+```bash
+# Check if DataHub secrets are properly mounted
+kubectl get secrets -n datahub-remote-executor
+kubectl describe secret datahub-access-token -n datahub-remote-executor
+```
+
+### Debug Commands
+
+```bash
+# Test PostgreSQL connection
+kubectl exec -it deployment/postgres -- psql -U testuser -d testdb -c "\dt"
+
+# Check executor environment
+kubectl exec -it deployment/datahub-executor-datahub-executor-worker -n datahub-remote-executor -- env | grep DATAHUB
+
+# Verify ConfigMap content
+kubectl describe configmap custom-transformers -n datahub-remote-executor
+
+# Check Python path and installed packages
+kubectl exec -it deployment/datahub-executor-datahub-executor-worker -n datahub-remote-executor -- python -c "import sys; print(sys.path)"
+```
+
+## 🎯 Testing Custom Transformations
+
+### 1. Validate Transformer Logic
+
+Test your transformer locally before deployment:
+
+```python
+# test_transformer.py
+from custom_transform_example import AddCustomOwnership
+from datahub.configuration.common import ConfigModel
+
+# Test configuration
+config = {"owners_json": "owners.json"}
+transformer = AddCustomOwnership.create(config, None)
+
+# Test transformation
+result = transformer.transform_aspect("test_urn", "ownership", None)
+print(f"Added owners: {[owner.owner for owner in result.owners]}")
+```
+
+### 2. Monitor Transformation Results
+
+```bash
+# Check transformation logs
+kubectl logs -n datahub-remote-executor -l app.kubernetes.io/name=datahub-executor-worker | grep -i "transform"
+
+# Verify ownership in DataHub
+# Navigate to a dataset in DataHub UI and check the Ownership tab
+```
+
+## 🔄 Updating Transformers
+
+### 1. Modify Transformer Code
+
+1. Edit files in `sample/transformers/`
+2. Update version in `setup.py` if needed
+3. Test changes locally
+
+### 2. Redeploy
+
+```bash
+# Apply Terraform changes
+terraform apply
+
+# Check if new ConfigMap is created
+kubectl get configmap custom-transformers -n datahub-remote-executor -o yaml
+
+# Restart executor pods to pick up changes
+kubectl rollout restart deployment/datahub-executor-datahub-executor-worker -n datahub-remote-executor
+```
+
+## 📊 Advanced Configuration
+
+### 1. Multiple Data Sources
+
+To add more data sources, create additional recipe files and configure them in DataHub:
+
+```bash
+# Create new recipe
+cp sample/source/postgres-recipe.yaml sample/source/mysql-recipe.yaml
+# Edit mysql-recipe.yaml with MySQL-specific configuration
+```
+
+### 2. Complex Transformers
+
+For more complex transformations:
+
+```python
+class AdvancedTransformer(BaseTransformer):
+    def transform(self, record):
+        # Apply business logic
+        # Add tags based on table names
+        # Set domains based on schema
+        # Apply data classification
+        return record
+```
+
+### 3. Environment-Specific Configuration
+
+Use different transformer configurations per environment:
+
+```bash
+# Development
+custom_transformers_path = "sample/transformers/dev"
+
+# Production  
+custom_transformers_path = "sample/transformers/prod"
+```
+
+## 🎓 Next Steps
+
+1. **Explore DataHub Features**: Lineage, Data Quality, Glossary
+2. **Add More Transformers**: Create transformers for tagging, domains, etc.
+3. **Scale the Setup**: Increase replica count for higher throughput
+4. **Monitor Performance**: Set up monitoring and alerting
+5. **Implement CI/CD**: Automate transformer deployment
+
+## 📚 Additional Resources
+
+- [DataHub Transformers Documentation](https://datahubproject.io/docs/metadata-ingestion/docs/transformer/intro)
+- [PostgreSQL Source Configuration](https://datahubproject.io/docs/generated/ingestion/sources/postgres)
+- [Remote Executor Setup](https://datahubproject.io/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor)
+- [DataHub API Guide](https://datahubproject.io/docs/api/datahub-apis)

--- a/remote-ingestion-executor-gke/sample/source/postgres-config.yaml
+++ b/remote-ingestion-executor-gke/sample/source/postgres-config.yaml
@@ -1,0 +1,112 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init-script
+  namespace: postgres-test
+data:
+  init.sql: |
+    -- Create sample database schema
+    CREATE SCHEMA IF NOT EXISTS ecommerce;
+    CREATE SCHEMA IF NOT EXISTS analytics;
+    
+    -- Create tables in ecommerce schema
+    CREATE TABLE IF NOT EXISTS ecommerce.customers (
+        customer_id SERIAL PRIMARY KEY,
+        email VARCHAR(255) UNIQUE NOT NULL,
+        first_name VARCHAR(100),
+        last_name VARCHAR(100),
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+    
+    CREATE TABLE IF NOT EXISTS ecommerce.products (
+        product_id SERIAL PRIMARY KEY,
+        sku VARCHAR(50) UNIQUE NOT NULL,
+        name VARCHAR(255) NOT NULL,
+        description TEXT,
+        price DECIMAL(10, 2),
+        category VARCHAR(100),
+        stock_quantity INTEGER DEFAULT 0,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+    
+    CREATE TABLE IF NOT EXISTS ecommerce.orders (
+        order_id SERIAL PRIMARY KEY,
+        customer_id INTEGER REFERENCES ecommerce.customers(customer_id),
+        order_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        status VARCHAR(50) DEFAULT 'pending',
+        total_amount DECIMAL(10, 2),
+        shipping_address TEXT
+    );
+    
+    CREATE TABLE IF NOT EXISTS ecommerce.order_items (
+        item_id SERIAL PRIMARY KEY,
+        order_id INTEGER REFERENCES ecommerce.orders(order_id),
+        product_id INTEGER REFERENCES ecommerce.products(product_id),
+        quantity INTEGER NOT NULL,
+        unit_price DECIMAL(10, 2),
+        line_total DECIMAL(10, 2)
+    );
+    
+    -- Create tables in analytics schema
+    CREATE TABLE IF NOT EXISTS analytics.page_views (
+        view_id SERIAL PRIMARY KEY,
+        session_id VARCHAR(100),
+        user_id INTEGER,
+        page_url VARCHAR(500),
+        view_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        referrer VARCHAR(500),
+        device_type VARCHAR(50)
+    );
+    
+    CREATE TABLE IF NOT EXISTS analytics.user_events (
+        event_id SERIAL PRIMARY KEY,
+        user_id INTEGER,
+        event_type VARCHAR(100),
+        event_data JSONB,
+        event_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+    
+    -- Create indexes
+    CREATE INDEX idx_customers_email ON ecommerce.customers(email);
+    CREATE INDEX idx_orders_customer ON ecommerce.orders(customer_id);
+    CREATE INDEX idx_orders_date ON ecommerce.orders(order_date);
+    CREATE INDEX idx_page_views_session ON analytics.page_views(session_id);
+    CREATE INDEX idx_user_events_user ON analytics.user_events(user_id);
+    
+    -- Insert sample data
+    INSERT INTO ecommerce.customers (email, first_name, last_name) VALUES
+    ('john.doe@example.com', 'John', 'Doe'),
+    ('jane.smith@example.com', 'Jane', 'Smith'),
+    ('bob.johnson@example.com', 'Bob', 'Johnson');
+    
+    INSERT INTO ecommerce.products (sku, name, description, price, category, stock_quantity) VALUES
+    ('LAPTOP-001', 'ThinkPad X1 Carbon', 'Business laptop with 14-inch display', 1499.99, 'Electronics', 10),
+    ('PHONE-001', 'iPhone 15 Pro', 'Latest iPhone with titanium design', 999.99, 'Electronics', 25),
+    ('BOOK-001', 'Clean Code', 'A Handbook of Agile Software Craftsmanship', 39.99, 'Books', 100);
+    
+    INSERT INTO ecommerce.orders (customer_id, status, total_amount, shipping_address) VALUES
+    (1, 'completed', 1539.98, '123 Main St, New York, NY 10001'),
+    (2, 'pending', 999.99, '456 Oak Ave, Los Angeles, CA 90001');
+    
+    INSERT INTO ecommerce.order_items (order_id, product_id, quantity, unit_price, line_total) VALUES
+    (1, 1, 1, 1499.99, 1499.99),
+    (1, 3, 1, 39.99, 39.99),
+    (2, 2, 1, 999.99, 999.99);
+    
+    -- Create views
+    CREATE VIEW ecommerce.customer_order_summary AS
+    SELECT 
+        c.customer_id,
+        c.email,
+        COUNT(DISTINCT o.order_id) as total_orders,
+        SUM(o.total_amount) as lifetime_value
+    FROM ecommerce.customers c
+    LEFT JOIN ecommerce.orders o ON c.customer_id = o.customer_id
+    GROUP BY c.customer_id, c.email;
+    
+    -- Grant permissions (for the ingestion user)
+    GRANT USAGE ON SCHEMA ecommerce TO PUBLIC;
+    GRANT USAGE ON SCHEMA analytics TO PUBLIC;
+    GRANT SELECT ON ALL TABLES IN SCHEMA ecommerce TO PUBLIC;
+    GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO PUBLIC;

--- a/remote-ingestion-executor-gke/sample/source/postgres-deployment.yaml
+++ b/remote-ingestion-executor-gke/sample/source/postgres-deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-secret
+  namespace: postgres-test
+type: Opaque
+stringData:
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: postgres123
+  POSTGRES_DB: testdb
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  namespace: postgres-test
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: postgres-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:15-alpine
+        ports:
+        - containerPort: 5432
+        envFrom:
+        - secretRef:
+            name: postgres-secret
+        volumeMounts:
+        - name: postgres-storage
+          mountPath: /var/lib/postgresql/data
+          subPath: postgres
+        - name: init-script
+          mountPath: /docker-entrypoint-initdb.d
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+      volumes:
+      - name: postgres-storage
+        persistentVolumeClaim:
+          claimName: postgres-pvc
+      - name: init-script
+        configMap:
+          name: postgres-init-script
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: postgres-test
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5432
+    targetPort: 5432
+  selector:
+    app: postgres

--- a/remote-ingestion-executor-gke/sample/source/postgres-recipe.yaml
+++ b/remote-ingestion-executor-gke/sample/source/postgres-recipe.yaml
@@ -1,0 +1,18 @@
+source:
+  type: postgres
+  config:
+    host_port: 'postgres.postgres-test.svc.cluster.local:5432'
+    database: testdb
+    username: postgres
+    include_tables: true
+    include_views: true
+    profiling:
+      enabled: true
+      profile_table_level_only: true
+    stateful_ingestion:
+      enabled: true
+    password: postgres123
+transformers:
+  - type: custom_transform_example.AddCustomOwnership
+    config:
+      owners_json: "/opt/datahub/transformers/owners.json"

--- a/remote-ingestion-executor-gke/sample/transformers/custom_transform_example.py
+++ b/remote-ingestion-executor-gke/sample/transformers/custom_transform_example.py
@@ -1,0 +1,69 @@
+import json
+from typing import List, Optional
+
+from datahub.configuration.common import ConfigModel
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.transformer.base_transformer import (
+    BaseTransformer,
+    SingleAspectTransformer,
+)
+from datahub.metadata.schema_classes import (
+    OwnerClass,
+    OwnershipClass,
+    OwnershipTypeClass,
+)
+
+class AddCustomOwnershipConfig(ConfigModel):
+    owners_json: str
+
+
+class AddCustomOwnership(BaseTransformer, SingleAspectTransformer):
+    """Transformer that adds owners to datasets according to a callback function."""
+
+    # context param to generate run metadata such as a run ID
+    ctx: PipelineContext
+    # as defined in the previous block
+    config: AddCustomOwnershipConfig
+
+    def __init__(self, config: AddCustomOwnershipConfig, ctx: PipelineContext):
+        super().__init__()
+        self.ctx = ctx
+        self.config = config
+
+        with open(self.config.owners_json, "r") as f:
+            raw_owner_urns = json.load(f)
+
+        self.owners = [
+            OwnerClass(owner=owner, type=OwnershipTypeClass.DATAOWNER)
+            for owner in raw_owner_urns
+        ]
+    
+    @classmethod
+    def create(cls, config_dict: dict, ctx: PipelineContext) -> "AddCustomOwnership":
+        config = AddCustomOwnershipConfig.parse_obj(config_dict)
+        return cls(config, ctx)
+    
+    def entity_types(self) -> List[str]:
+        return ["dataset"]
+
+    def aspect_name(self) -> str:
+        return "ownership"
+
+    def transform_aspect(  # type: ignore
+        self, entity_urn: str, aspect_name: str, aspect: Optional[OwnershipClass]
+    ) -> Optional[OwnershipClass]:
+
+        owners_to_add = self.owners
+        assert aspect is None or isinstance(aspect, OwnershipClass)
+
+        if owners_to_add:
+            ownership = (
+                aspect
+                if aspect
+                else OwnershipClass(
+                    owners=[],
+                )
+            )
+            ownership.owners.extend(owners_to_add)
+
+        return ownership

--- a/remote-ingestion-executor-gke/sample/transformers/owners.json
+++ b/remote-ingestion-executor-gke/sample/transformers/owners.json
@@ -1,0 +1,6 @@
+[
+    "urn:li:corpuser:athos",
+    "urn:li:corpuser:porthos",
+    "urn:li:corpuser:aramis",
+    "urn:li:corpGroup:the_three_musketeers"
+]

--- a/remote-ingestion-executor-gke/sample/transformers/setup.py
+++ b/remote-ingestion-executor-gke/sample/transformers/setup.py
@@ -1,0 +1,14 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="custom_transform_example",
+    version="1.0",
+    packages=find_packages(),
+    # if you don't already have DataHub installed, add it under install_requires
+    # install_requires=["acryl-datahub"],
+    entry_points={
+        "datahub.ingestion.transformer.plugins": [
+            "custom_transform_example_alias = custom_transform_example:AddCustomOwnership",
+        ],
+    },
+)

--- a/remote-ingestion-executor-gke/terraform.tfvars.example
+++ b/remote-ingestion-executor-gke/terraform.tfvars.example
@@ -1,0 +1,68 @@
+# Example terraform.tfvars file for DataHub Remote Executor deployment
+# Copy this file to terraform.tfvars and update the values
+
+# Required variables
+project_id     = "your-gcp-project-id"
+cluster_name   = "your-gke-cluster-name"
+region         = "us-central1"
+
+# DataHub Configuration
+datahub_gms_url      = "https://your-datahub-instance.com/gms"
+datahub_access_token = "your-datahub-access-token"
+datahub_remote_executor_pool_id     = "gke-executor-pool"
+
+# Container Registry Configuration
+container_registry_url      = "gcr.io/your-project-id"  # or us-docker.pkg.dev/your-project-id/your-repo
+container_registry_username = "_json_key"                # Use "_json_key" for GCR with service account key
+container_registry_password = "your-service-account-key-json"  # Base64 encoded service account key
+
+# Optional: Override default values
+kubernetes_namespace = "datahub-remote-executor"
+environment         = "dev"  # dev, test, or prod
+
+# Image Configuration
+image_repository = "docker.datahub.com/enterprise/datahub-executor"
+image_tag       = "v0.3.13-acryl"
+
+# Scaling Configuration
+replica_count              = 1
+ingestion_max_workers      = 2
+ingestion_signal_poll_interval = 5
+monitors_max_workers       = 2
+
+# Resource Configuration
+resources_requests_memory = "512Mi"
+resources_requests_cpu    = "250m"
+resources_limits_memory   = "1Gi"
+resources_limits_cpu      = "500m"
+
+# GKE Configuration
+create_namespace           = true
+enable_workload_identity   = false  # Set to true if you want to use Workload Identity
+gcp_service_account_name   = "datahub-executor-sa"
+
+# Additional Configuration
+enable_debug = false
+
+# Custom Transformers Configuration (automatically enabled when path is set)
+custom_transformers_path = "sample/transformers"  # Set to "" to disable custom transformers
+
+# Optional: Pod annotations
+pod_annotations = {
+  "co.elastic.logs/enabled" = "true"
+}
+
+# Optional: Node selector
+node_selector = {
+  "cloud.google.com/gke-nodepool" = "default-pool"
+}
+
+# Optional: Tolerations
+# tolerations = [
+#   {
+#     key      = "node-role"
+#     operator = "Equal"
+#     value    = "datahub"
+#     effect   = "NoSchedule"
+#   }
+# ]

--- a/remote-ingestion-executor-gke/variables.tf
+++ b/remote-ingestion-executor-gke/variables.tf
@@ -1,0 +1,205 @@
+# Terraform variables for DataHub Remote Executor deployment on GKE
+
+variable "project_id" {
+  description = "The GCP project ID where resources will be created"
+  type        = string
+}
+
+variable "region" {
+  description = "The GCP region for the GKE cluster"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "cluster_name" {
+  description = "The name of the existing GKE cluster"
+  type        = string
+}
+
+variable "kubernetes_namespace" {
+  description = "Kubernetes namespace for DataHub executor deployment"
+  type        = string
+  default     = "datahub-executor"
+}
+
+variable "environment" {
+  description = "Environment name (dev, test, prod)"
+  type        = string
+  default     = "dev"
+  
+  validation {
+    condition     = contains(["dev", "test", "prod"], var.environment)
+    error_message = "Environment must be one of: dev, test, prod."
+  }
+}
+
+# DataHub Configuration
+variable "datahub_gms_url" {
+  description = "DataHub GMS endpoint URL"
+  type        = string
+}
+
+variable "datahub_access_token" {
+  description = "DataHub access token for authentication"
+  type        = string
+  sensitive   = true
+}
+
+variable "datahub_remote_executor_pool_id" {
+  description = "DataHub executor pool ID"
+  type        = string
+  default     = "gke-executor-pool"
+}
+
+# Container Registry Configuration
+variable "container_registry_url" {
+  description = "Container registry URL (e.g., gcr.io/project-id, us-docker.pkg.dev/project-id/repo)"
+  type        = string
+  default     = "docker.datahub.com/enterprise"
+}
+
+variable "container_registry_username" {
+  description = "Container registry username"
+  type        = string
+  default     = "_json_key"
+}
+
+variable "container_registry_password" {
+  description = "Container registry password or service account key"
+  type        = string
+  sensitive   = true
+}
+
+# Image Configuration
+variable "image_repository" {
+  description = "DataHub executor image repository"
+  type        = string
+  default     = "docker.datahub.com/enterprise/datahub-executor"
+}
+
+variable "image_tag" {
+  description = "DataHub executor image tag"
+  type        = string
+  default     = "v0.3.13-acryl"
+}
+
+# Executor Configuration
+variable "replica_count" {
+  description = "Number of executor replicas"
+  type        = number
+  default     = 1
+}
+
+variable "ingestion_max_workers" {
+  description = "Maximum number of ingestion workers"
+  type        = number
+  default     = 2
+}
+
+variable "ingestion_signal_poll_interval" {
+  description = "Signal polling interval for ingestion workers (seconds)"
+  type        = number
+  default     = 5
+}
+
+variable "monitors_max_workers" {
+  description = "Maximum number of monitor workers"
+  type        = number
+  default     = 2
+}
+
+# Resource Configuration
+variable "resources_requests_memory" {
+  description = "Memory requests for executor pods"
+  type        = string
+  default     = "512Mi"
+}
+
+variable "resources_requests_cpu" {
+  description = "CPU requests for executor pods"
+  type        = string
+  default     = "250m"
+}
+
+variable "resources_limits_memory" {
+  description = "Memory limits for executor pods"
+  type        = string
+  default     = "1Gi"
+}
+
+variable "resources_limits_cpu" {
+  description = "CPU limits for executor pods"
+  type        = string
+  default     = "500m"
+}
+
+# GKE Configuration
+variable "create_namespace" {
+  description = "Whether to create the Kubernetes namespace"
+  type        = bool
+  default     = true
+}
+
+variable "enable_workload_identity" {
+  description = "Enable Workload Identity for the service account"
+  type        = bool
+  default     = false
+}
+
+variable "gcp_service_account_name" {
+  description = "Name of the GCP service account for Workload Identity (if enabled)"
+  type        = string
+  default     = "datahub-executor-sa"
+}
+
+# Helm Chart Configuration
+variable "helm_chart_path" {
+  description = "Path to the local Helm chart"
+  type        = string
+  default     = "./datahub-executor-helm/charts/datahub-executor-worker"
+}
+
+variable "helm_release_name" {
+  description = "Name of the Helm release"
+  type        = string
+  default     = "datahub-executor"
+}
+
+# Additional Configuration
+variable "pod_annotations" {
+  description = "Additional annotations for executor pods"
+  type        = map(string)
+  default     = {}
+}
+
+variable "node_selector" {
+  description = "Node selector for executor pods"
+  type        = map(string)
+  default     = {}
+}
+
+variable "tolerations" {
+  description = "Tolerations for executor pods"
+  type = list(object({
+    key      = optional(string)
+    operator = optional(string, "Equal")
+    value    = optional(string)
+    effect   = optional(string)
+  }))
+  default = []
+}
+
+variable "enable_debug" {
+  description = "Enable debug mode for DataHub executor"
+  type        = bool
+  default     = false
+}
+
+# Custom Transformer Configuration
+variable "custom_transformers_path" {
+  description = "Path to the directory containing custom transformers. Set to empty string to disable custom transformers."
+  type        = string
+  default     = "sample/transformers"
+}
+
+# Note: Custom transformers are automatically enabled when custom_transformers_path is set to a non-empty value

--- a/remote-ingestion-executor-gke/versions.tf
+++ b/remote-ingestion-executor-gke/versions.tf
@@ -1,0 +1,22 @@
+# Terraform and provider version constraints
+
+terraform {
+  required_version = ">= 1.0"
+  
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23"
+    }
+    
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.11"
+    }
+  }
+}


### PR DESCRIPTION
This Terraform repo includes:
- A Terraform module that deploys the Datahub remote executor into a specified namespace of a pre-existing Google Kubernetes Service (GKS)
- It includes the ability to mount custom transformer Python code into the executor - [Custom Transformer Docs](https://docs.datahub.com/docs/metadata-ingestion/docs/transformer/dataset_transformer#writing-a-custom-transformer-from-scratch)
- It also includes a small sample Postgres DB deployment that can be used to verify that the executor is working correctly