### PR TITLE
fix(remote-executor): tolerate null ephemeral_storage (default deploy fails)

### DIFF
--- a/remote-ingestion-executor/main.tf
+++ b/remote-ingestion-executor/main.tf
@@ -30,12 +30,6 @@ module "ecs_service" {
 
   cpu    = var.cpu
   memory = var.memory
-  # The upstream ecs service module (v5.x) gates the ephemeral_storage block with
-  # `length(var.ephemeral_storage) > 0`, which errors on null. Pass an empty map
-  # (length 0 -> block omitted) when unset, or a single-entry map when set, so a
-  # null default doesn't break `terraform apply`. A plain `... ? {} : {...}`
-  # ternary won't do: type-unification would turn the empty branch into
-  # `{ size_in_gib = null }` (length 1). Maps keep the empty case truly empty.
   ephemeral_storage = var.ephemeral_storage == null ? tomap({}) : tomap({ size_in_gib = var.ephemeral_storage.size_in_gib })
   desired_count     = var.desired_count
   launch_type       = "FARGATE"

--- a/remote-ingestion-executor/main.tf
+++ b/remote-ingestion-executor/main.tf
@@ -28,9 +28,15 @@ module "ecs_service" {
   task_exec_ssm_param_arns    = var.task_exec_ssm_param_arns
   task_exec_secret_arns       = var.task_exec_secret_arns
 
-  cpu               = var.cpu
-  memory            = var.memory
-  ephemeral_storage = var.ephemeral_storage
+  cpu    = var.cpu
+  memory = var.memory
+  # The upstream ecs service module (v5.x) gates the ephemeral_storage block with
+  # `length(var.ephemeral_storage) > 0`, which errors on null. Pass an empty map
+  # (length 0 -> block omitted) when unset, or a single-entry map when set, so a
+  # null default doesn't break `terraform apply`. A plain `... ? {} : {...}`
+  # ternary won't do: type-unification would turn the empty branch into
+  # `{ size_in_gib = null }` (length 1). Maps keep the empty case truly empty.
+  ephemeral_storage = var.ephemeral_storage == null ? tomap({}) : tomap({ size_in_gib = var.ephemeral_storage.size_in_gib })
   desired_count     = var.desired_count
   launch_type       = "FARGATE"
 


### PR DESCRIPTION
## What
Makes `remote-ingestion-executor` handle a null `ephemeral_storage` (its default) so a plain `terraform apply` doesn't fail.

## The bug
`ephemeral_storage` defaults to `null` and was passed straight into `terraform-aws-modules/ecs//modules/service` (pinned v5.9.2), whose task definition gates the block with:
```hcl
dynamic "ephemeral_storage" {
  for_each = length(var.ephemeral_storage) > 0 ? [var.ephemeral_storage] : []
```
`length(null)` errors, so **any deploy that doesn't set `ephemeral_storage` fails**:
```
Error: Invalid function argument — while calling length(value)
Invalid value for "value" parameter: argument must not be null.
```
(The ECS module v6.x switched to `!= null`, but that's a major bump.)

## The fix
```hcl
ephemeral_storage = var.ephemeral_storage == null ? tomap({}) : tomap({ size_in_gib = var.ephemeral_storage.size_in_gib })
```
- unset → empty map → `length() == 0` → block omitted (Fargate default 20 GiB)
- set → `{ size_in_gib = N }` → `length() == 1` → block created

A `null ? {} : {…}` ternary does **not** work: Terraform type-unification rewrites the empty branch to `{ size_in_gib = null }` (length 1). Maps keep the empty case genuinely empty.

## Verification
- `terraform console`: null-branch `length` = 0, set-branch = 1, `.size_in_gib` = 21.
- `terraform validate` on `example/` (which leaves `ephemeral_storage` unset) passes.

Found by the Remote Executor deploy-path drift test (it deploys the module with defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)