### PR TITLE
feat: Use uv hardlinking to prevent storage expansion

### DIFF
--- a/remote-ingestion-executor/main.tf
+++ b/remote-ingestion-executor/main.tf
@@ -138,6 +138,10 @@ module "ecs_service" {
           value = var.datahub.executor_databricks_timeout
         },
         {
+          name  = "UV_LINK_MODE"
+          value = var.datahub.executor_uv_link_mode
+        },
+        {
           name  = "AWS_REGION"
           value = data.aws_region.current.name
         },

--- a/remote-ingestion-executor/variables.tf
+++ b/remote-ingestion-executor/variables.tf
@@ -41,6 +41,10 @@ variable "datahub" {
     executor_bigquery_timeout   = optional(number, 600)
     executor_redshift_timeout   = optional(number, 600)
     executor_databricks_timeout = optional(number, 600)
+    # uv link mode for building ingestion venvs. "hardlink" (default) shares package bytes with the
+    # uv cache (no per-venv copy / ephemeral spike); needs the venv dir and cache on the same
+    # filesystem. Falls back to "copy" automatically where hardlinks aren't possible.
+    executor_uv_link_mode = optional(string, "hardlink")
   })
 
   validation {


### PR DESCRIPTION
Most FS, do not support CoW, in such cases UV_LINK_MODE might default from clone to copy instead of hardlink, therefor causing huge spikes of storage consumption whenever an ingestion is started. On average it can take 400 MB storage for a new venv in copy mode, compared with 50 MB (.pyc files only) in hardlink. This was one of the causes of disk pressure-based evictions of the executor pods.